### PR TITLE
fix: suggestion popover styling

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -85,7 +85,7 @@ div#mathlive-suggestion-popover {
   & li {
     /* Suggestion item */
     margin: 0;
-    padding: 0 0.25rem;
+    padding: 0.25rem;
     border-radius: 4px;
     width: 100%;
     gap: 0;

--- a/src/style.css
+++ b/src/style.css
@@ -90,6 +90,11 @@ div#mathlive-suggestion-popover {
     width: 100%;
     gap: 0;
 
+    &.ML__popover__current {
+      background-color: var(--ls-selection-background-color);
+      color: var(--ls-selection-text-color);
+    }
+
     & .ML__popover__latex {
       flex-grow: 1;
       text-align: start;

--- a/src/style.css
+++ b/src/style.css
@@ -74,6 +74,32 @@ div[data-ref='logseq-live-math'] {
 div#mathlive-suggestion-popover {
   background-color: var(--ls-primary-background-color);
   z-index: var(--ls-z-index-level-2);
+
+  & ul {
+    padding: 8px;
+    /* Limit min-width to reduce clutter */
+    min-width: 16ch;
+    gap: 0.25rem;
+  }
+
+  & li {
+    /* Suggestion item */
+    margin: 0;
+    padding: 0 0.25rem;
+    border-radius: 4px;
+    width: 100%;
+    gap: 0;
+
+    & .ML__popover__latex {
+      flex-grow: 1;
+      text-align: start;
+      margin-right: 0.5rem;
+    }
+
+    & .ML__popover__command {
+      font-size: 1rem;
+    }
+  }
 }
 
 div#mathlive-suggestion-popover.top-tip::after {
@@ -84,7 +110,3 @@ div#mathlive-suggestion-popover.bottom-tip::after {
   border-top-color: var(--ls-primary-background-color);
 }
 
-li.ML__popover__current {
-  background-color: var(--ls-selection-background-color);
-  color: var(--ls-selection-text-color);
-}


### PR DESCRIPTION
The suggestion popover is cluttered (word wrap, gap on the end, width bouncing during input, too huge gap on y-axis), try to fix.

## Demo

### Before

<img width="443" alt="image" src="https://github.com/AllanChain/logseq-live-math/assets/21151119/d158e6d7-6e57-4250-92d2-a81f4aab7a03">

<img width="433" alt="image" src="https://github.com/AllanChain/logseq-live-math/assets/21151119/e2b3c9ca-e3c8-4770-aa2a-53952147b4c0">


### After

<img width="387" alt="image" src="https://github.com/AllanChain/logseq-live-math/assets/21151119/3d89f0cc-0b33-4893-9b4f-44e09ec69866">

<img width="437" alt="image" src="https://github.com/AllanChain/logseq-live-math/assets/21151119/0925e0bb-848a-444d-8f7a-89b71e8c6fcb">
